### PR TITLE
Main favicon.ico was not being displayed

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <link rel="icon" type="image/x-icon" href="%PUBLIC_URL%/assets/layout/images/favicon.ico">
+    <link rel="icon" type="image/x-icon" href="%PUBLIC_URL%/favicon.ico">
     <style type="text/css">
         html,
         body,


### PR DESCRIPTION
The favicon.ico was not being displayed because it has the wrong URL location.