### PR TITLE
Fix spelling

### DIFF
--- a/layout/AppMenu.js
+++ b/layout/AppMenu.js
@@ -167,7 +167,7 @@ const AppMenu = () => {
         <MenuProvider>
             <ul className="layout-menu">
                 {model.map((item, i) => {
-                    return !item.seperator ? <AppMenuitem item={item} root={true} index={i} key={item.label} /> : <li className="menu-separator"></li>;
+                    return !item.separator ? <AppMenuitem item={item} root={true} index={i} key={item.label} /> : <li className="menu-separator"></li>;
                 })}
 
                 <Link href="https://www.primefaces.org/primeblocks-react">


### PR DESCRIPTION
Here it is spelled correctly https://www.primefaces.org/primereact/menumodel/ with an a