### PR TITLE
Dashboard responsiveness improved

### DIFF
--- a/sakai-js/package-lock.json
+++ b/sakai-js/package-lock.json
@@ -14,7 +14,7 @@
                 "next": "13.2.3",
                 "primeflex": "3.3.0",
                 "primeicons": "^6.0.1",
-                "primereact": "9.2.2",
+                "primereact": "9.2.3",
                 "react": "18.2.0",
                 "react-dom": "18.2.0"
             },
@@ -2858,9 +2858,9 @@
             "integrity": "sha512-KDeO94CbWI4pKsPnYpA1FPjo79EsY9I+M8ywoPBSf9XMXoe/0crjbUK7jcQEDHuc0ZMRIZsxH3TYLv4TUtHmAA=="
         },
         "node_modules/primereact": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/primereact/-/primereact-9.2.2.tgz",
-            "integrity": "sha512-GGkxLHOdQot5DYW9Z7vTPPaDwzjvnderzLWAXda220teNScAJNtXCIqR3QESi4c9OaNbGD4IlBlhXr++z8fjsw==",
+            "version": "9.2.3",
+            "resolved": "https://registry.npmjs.org/primereact/-/primereact-9.2.3.tgz",
+            "integrity": "sha512-LIkVpgH2EZOn0CViZ/vFxBLWgK/ULYYYNTFch6CUvvJ2HUDnn3sAxII7ltblwEmT8hryCiEHDU/AiG8cqXVmNA==",
             "dependencies": {
                 "@types/react-transition-group": "^4.4.1",
                 "react-transition-group": "^4.4.1"

--- a/sakai-js/pages/index.js
+++ b/sakai-js/pages/index.js
@@ -213,7 +213,7 @@ const Dashboard = () => {
                         </div>
                     </div>
                     <ul className="list-none p-0 m-0">
-                        <li className="flex flex-column md:flex-row md:align-items-center md:justify-content-between mb-4">
+                        <li className="flex flex-column sm:flex-row sm:align-items-center sm:justify-content-between mb-4">
                             <div>
                                 <span className="text-900 font-medium mr-2 mb-1 md:mb-0">Space T-Shirt</span>
                                 <div className="mt-1 text-600">Clothing</div>
@@ -225,7 +225,7 @@ const Dashboard = () => {
                                 <span className="text-orange-500 ml-3 font-medium">%50</span>
                             </div>
                         </li>
-                        <li className="flex flex-column md:flex-row md:align-items-center md:justify-content-between mb-4">
+                        <li className="flex flex-column sm:flex-row sm:align-items-center sm:justify-content-between mb-4">
                             <div>
                                 <span className="text-900 font-medium mr-2 mb-1 md:mb-0">Portal Sticker</span>
                                 <div className="mt-1 text-600">Accessories</div>
@@ -237,7 +237,7 @@ const Dashboard = () => {
                                 <span className="text-cyan-500 ml-3 font-medium">%16</span>
                             </div>
                         </li>
-                        <li className="flex flex-column md:flex-row md:align-items-center md:justify-content-between mb-4">
+                        <li className="flex flex-column sm:flex-row sm:align-items-center sm:justify-content-between mb-4">
                             <div>
                                 <span className="text-900 font-medium mr-2 mb-1 md:mb-0">Supernova Sticker</span>
                                 <div className="mt-1 text-600">Accessories</div>
@@ -249,7 +249,7 @@ const Dashboard = () => {
                                 <span className="text-pink-500 ml-3 font-medium">%67</span>
                             </div>
                         </li>
-                        <li className="flex flex-column md:flex-row md:align-items-center md:justify-content-between mb-4">
+                        <li className="flex flex-column sm:flex-row sm:align-items-center sm:justify-content-between mb-4">
                             <div>
                                 <span className="text-900 font-medium mr-2 mb-1 md:mb-0">Wonders Notebook</span>
                                 <div className="mt-1 text-600">Office</div>
@@ -261,7 +261,7 @@ const Dashboard = () => {
                                 <span className="text-green-500 ml-3 font-medium">%35</span>
                             </div>
                         </li>
-                        <li className="flex flex-column md:flex-row md:align-items-center md:justify-content-between mb-4">
+                        <li className="flex flex-column sm:flex-row sm:align-items-center sm:justify-content-between mb-4">
                             <div>
                                 <span className="text-900 font-medium mr-2 mb-1 md:mb-0">Mat Black Case</span>
                                 <div className="mt-1 text-600">Accessories</div>
@@ -273,7 +273,7 @@ const Dashboard = () => {
                                 <span className="text-purple-500 ml-3 font-medium">%75</span>
                             </div>
                         </li>
-                        <li className="flex flex-column md:flex-row md:align-items-center md:justify-content-between mb-4">
+                        <li className="flex flex-column sm:flex-row sm:align-items-center sm:justify-content-between mb-4">
                             <div>
                                 <span className="text-900 font-medium mr-2 mb-1 md:mb-0">Robots T-Shirt</span>
                                 <div className="mt-1 text-600">Clothing</div>

--- a/sakai-ts/pages/index.tsx
+++ b/sakai-ts/pages/index.tsx
@@ -218,7 +218,7 @@ const Dashboard = () => {
                         </div>
                     </div>
                     <ul className="list-none p-0 m-0">
-                        <li className="flex flex-column md:flex-row md:align-items-center md:justify-content-between mb-4">
+                        <li className="flex flex-column sm:flex-row sm:align-items-center sm:justify-content-between mb-4">
                             <div>
                                 <span className="text-900 font-medium mr-2 mb-1 md:mb-0">Space T-Shirt</span>
                                 <div className="mt-1 text-600">Clothing</div>
@@ -230,7 +230,7 @@ const Dashboard = () => {
                                 <span className="text-orange-500 ml-3 font-medium">%50</span>
                             </div>
                         </li>
-                        <li className="flex flex-column md:flex-row md:align-items-center md:justify-content-between mb-4">
+                        <li className="flex flex-column sm:flex-row sm:align-items-center sm:justify-content-between mb-4">
                             <div>
                                 <span className="text-900 font-medium mr-2 mb-1 md:mb-0">Portal Sticker</span>
                                 <div className="mt-1 text-600">Accessories</div>
@@ -242,7 +242,7 @@ const Dashboard = () => {
                                 <span className="text-cyan-500 ml-3 font-medium">%16</span>
                             </div>
                         </li>
-                        <li className="flex flex-column md:flex-row md:align-items-center md:justify-content-between mb-4">
+                        <li className="flex flex-column sm:flex-row sm:align-items-center sm:justify-content-between mb-4">
                             <div>
                                 <span className="text-900 font-medium mr-2 mb-1 md:mb-0">Supernova Sticker</span>
                                 <div className="mt-1 text-600">Accessories</div>
@@ -254,7 +254,7 @@ const Dashboard = () => {
                                 <span className="text-pink-500 ml-3 font-medium">%67</span>
                             </div>
                         </li>
-                        <li className="flex flex-column md:flex-row md:align-items-center md:justify-content-between mb-4">
+                        <li className="flex flex-column sm:flex-row sm:align-items-center sm:justify-content-between mb-4">
                             <div>
                                 <span className="text-900 font-medium mr-2 mb-1 md:mb-0">Wonders Notebook</span>
                                 <div className="mt-1 text-600">Office</div>
@@ -266,7 +266,7 @@ const Dashboard = () => {
                                 <span className="text-green-500 ml-3 font-medium">%35</span>
                             </div>
                         </li>
-                        <li className="flex flex-column md:flex-row md:align-items-center md:justify-content-between mb-4">
+                        <li className="flex flex-column sm:flex-row sm:align-items-center sm:justify-content-between mb-4">
                             <div>
                                 <span className="text-900 font-medium mr-2 mb-1 md:mb-0">Mat Black Case</span>
                                 <div className="mt-1 text-600">Accessories</div>
@@ -278,7 +278,7 @@ const Dashboard = () => {
                                 <span className="text-purple-500 ml-3 font-medium">%75</span>
                             </div>
                         </li>
-                        <li className="flex flex-column md:flex-row md:align-items-center md:justify-content-between mb-4">
+                        <li className="flex flex-column sm:flex-row sm:align-items-center sm:justify-content-between mb-4">
                             <div>
                                 <span className="text-900 font-medium mr-2 mb-1 md:mb-0">Robots T-Shirt</span>
                                 <div className="mt-1 text-600">Clothing</div>


### PR DESCRIPTION
**Description**
This pull request addresses an issue where the spacing in the best-selling section of the Dashboard did not change until the md limit was hit. The spacing should change when the sm limit is reached instead. In addition, the flex direction previously created a bigger gap between the progress bar and border, but this has been substantially reduced with this commit.

**Changes made**
- Breakpoint changed form md to sm

**Testing**
N/A